### PR TITLE
added replacements for wet/wat paths so we get cdx filenames out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ nosetests.xml
 
 # Other
 mrjob.conf
+mrjob*.conf
 index_env.sh
 
 .vagrant

--- a/indexwarcsjob.py
+++ b/indexwarcsjob.py
@@ -106,8 +106,8 @@ class IndexWARCJob(MRJob):
         # set cdx path
         cdx_path = warc_path.replace('crawl-data', 'cc-index/cdx')
         cdx_path = cdx_path.replace('.warc.gz', '.cdx.gz')
-        cdx_path = cdx_path.replace('.wet.gz', '.wet.cdx.gz')
-        cdx_path = cdx_path.replace('.wat.gz', '.wat.cdx.gz')
+        cdx_path = cdx_path.replace('.warc.wet.gz', '.wet.cdx.gz')
+        cdx_path = cdx_path.replace('.warc.wat.gz', '.wat.cdx.gz')
         return cdx_path
 
     def _load_and_index(self, warc_path):

--- a/indexwarcsjob.py
+++ b/indexwarcsjob.py
@@ -106,6 +106,8 @@ class IndexWARCJob(MRJob):
         # set cdx path
         cdx_path = warc_path.replace('crawl-data', 'cc-index/cdx')
         cdx_path = cdx_path.replace('.warc.gz', '.cdx.gz')
+        cdx_path = cdx_path.replace('.wet.gz', '.wet.cdx.gz')
+        cdx_path = cdx_path.replace('.wat.gz', '.wat.cdx.gz')
         return cdx_path
 
     def _load_and_index(self, warc_path):


### PR DESCRIPTION
Prior to this change, the output files ended up being same as the input files, which does not reflect the fact that they are cdx files. This change adds the cdx suffix into the filename.