### PR TITLE
Allow to filter CDXJ fields when building ZipNum index 

### DIFF
--- a/run_index_ccpyspark.sh
+++ b/run_index_ccpyspark.sh
@@ -62,6 +62,7 @@ WARC_CDX="s3a://$WARC_CDX_BUCKET/$CRAWL/cdx/segments/*/*/*.cdx.gz"
 ### ZipNum definitions
 ZIPNUM_N_LINES=3000
 ZIPNUM_N_PARTITIONS=300
+ZIPNUM_CDXJ_FIELDS="digest,filename,length,mime,mime-detected,offset,recordid,redirect,status,url,truncated,charset,languages"
 
 # SPLIT_FILE could be reused from previous crawl with similar distribution of URLs, see REUSE_SPLIT_FILE
 SPLIT_FILE="s3a://$WARC_CDX_BUCKET/$CRAWL/partition_boundaries.json"
@@ -183,6 +184,7 @@ $SPARK_HOME/bin/spark-submit \
     --partition_boundaries_file="$SPLIT_FILE" \
     --num_lines=$ZIPNUM_N_LINES \
     --num_output_partitions=$ZIPNUM_N_PARTITIONS \
+    --cdx_output_fields="$ZIPNUM_CDXJ_FIELDS" \
     "$WARC_CDX" ""
 
 

--- a/zipnumcluster_cc_pyspark.py
+++ b/zipnumcluster_cc_pyspark.py
@@ -5,7 +5,7 @@ import os
 import re
 import zlib
 
-from typing import Iterator, Tuple
+from typing import Iterator, Set, Tuple
 
 import boto3
 import botocore
@@ -48,6 +48,11 @@ class ZipNumClusterCdx(CCFileProcessorSparkJob):
         parser.add_argument("--num_output_partitions", type=int, required=False,
                             default=300,
                             help="Number of partitions/shards")
+        parser.add_argument("--cdx_output_remove_fields", required=False,
+                            help="Comma-separated list of CDXJ output fields to be removed.")
+        parser.add_argument("--cdx_output_fields", required=False,
+                            help="Comma-separated list of CDXJ output fields. "
+                            "Fields not in this list are removed from output records.")
         # suppress help for ignored arguments
         parser.add_argument("--output_format", help=argparse.SUPPRESS)
         parser.add_argument("--output_compression", help=argparse.SUPPRESS)
@@ -63,6 +68,20 @@ class ZipNumClusterCdx(CCFileProcessorSparkJob):
             return ((surt_key, timestamp), json_str)
         except:
             return None
+
+    @staticmethod
+    def remove_cdx_fields(value: Tuple[Tuple[str, str], str], remove_fields: Set[str]) -> str:
+        data = json.loads(value[1])
+        for f in remove_fields:
+            if f in data:
+                del data[f]
+        return (value[0], json.dumps(data))
+
+    @staticmethod
+    def keep_only_cdx_fields(value: Tuple[Tuple[str, str], str], keep_fields: Set[str]) -> str:
+        data = json.loads(value[1])
+        data = {k: v for k, v in data.items() if k in keep_fields}
+        return (value[0], json.dumps(data))
 
     @staticmethod
     def get_partition_id(key: str, boundaries_data) -> int:
@@ -242,6 +261,22 @@ class ZipNumClusterCdx(CCFileProcessorSparkJob):
 
         rdd = session.sparkContext.textFile(input_url).map(
             self.parse_line).filter(lambda x: x is not None)
+
+        if self.args.cdx_output_remove_fields:
+            # CDXJ fields to remove
+            remove_fields = set(
+                filter(len, map(str.strip, self.args.cdx_output_remove_fields.split(','))))
+            if remove_fields:
+                self.get_logger(session).info("Filtering CDXJ fields, removing: {}".format(remove_fields))
+                rdd = rdd.map(lambda x: ZipNumClusterCdx.remove_cdx_fields(x, remove_fields))
+
+        if self.args.cdx_output_fields:
+            # CDXJ fields to keep only
+            fields = set(
+                filter(len, map(str.strip, self.args.cdx_output_fields.split(','))))
+            if fields:
+                self.get_logger(session).info("Filtering CDXJ fields, keep only: {}".format(fields))
+                rdd = rdd.map(lambda x: ZipNumClusterCdx.keep_only_cdx_fields(x, fields))
 
         boundaries = None
         self.get_logger(session).info(f"Boundaries file: {boundaries_file_uri}")

--- a/zipnumcluster_cc_pyspark.py
+++ b/zipnumcluster_cc_pyspark.py
@@ -48,11 +48,14 @@ class ZipNumClusterCdx(CCFileProcessorSparkJob):
         parser.add_argument("--num_output_partitions", type=int, required=False,
                             default=300,
                             help="Number of partitions/shards")
-        parser.add_argument("--cdx_output_remove_fields", required=False,
-                            help="Comma-separated list of CDXJ output fields to be removed.")
-        parser.add_argument("--cdx_output_fields", required=False,
-                            help="Comma-separated list of CDXJ output fields. "
-                            "Fields not in this list are removed from output records.")
+        output_fields_group = parser.add_mutually_exclusive_group()
+        output_fields_group.add_argument(
+            "--cdx_output_remove_fields", required=False,
+            help="Comma-separated list of CDXJ output fields to be removed.")
+        output_fields_group.add_argument(
+            "--cdx_output_fields", required=False,
+            help="Comma-separated list of CDXJ output fields. "
+            "Fields not in this list are removed from output records.")
         # suppress help for ignored arguments
         parser.add_argument("--output_format", help=argparse.SUPPRESS)
         parser.add_argument("--output_compression", help=argparse.SUPPRESS)
@@ -267,15 +270,16 @@ class ZipNumClusterCdx(CCFileProcessorSparkJob):
             remove_fields = set(
                 filter(len, map(str.strip, self.args.cdx_output_remove_fields.split(','))))
             if remove_fields:
-                self.get_logger(session).info("Filtering CDXJ fields, removing: {}".format(remove_fields))
+                self.get_logger(session).info(
+                    "Filtering CDXJ fields, removing: {}".format(remove_fields))
                 rdd = rdd.map(lambda x: ZipNumClusterCdx.remove_cdx_fields(x, remove_fields))
-
-        if self.args.cdx_output_fields:
+        elif self.args.cdx_output_fields:
             # CDXJ fields to keep only
             fields = set(
                 filter(len, map(str.strip, self.args.cdx_output_fields.split(','))))
             if fields:
-                self.get_logger(session).info("Filtering CDXJ fields, keep only: {}".format(fields))
+                self.get_logger(session).info(
+                    "Filtering CDXJ fields, keep only: {}".format(fields))
                 rdd = rdd.map(lambda x: ZipNumClusterCdx.keep_only_cdx_fields(x, fields))
 
         boundaries = None

--- a/zipnumcluster_cc_pyspark.py
+++ b/zipnumcluster_cc_pyspark.py
@@ -260,7 +260,7 @@ class ZipNumClusterCdx(CCFileProcessorSparkJob):
         temporary_output_base_url = self.args.temporary_output_base_url
 
         rdd = session.sparkContext.textFile(input_url).map(
-            self.parse_line).filter(lambda x: x is not None)
+            ZipNumClusterCdx.parse_line).filter(lambda x: x is not None)
 
         if self.args.cdx_output_remove_fields:
             # CDXJ fields to remove
@@ -283,7 +283,7 @@ class ZipNumClusterCdx(CCFileProcessorSparkJob):
         if boundaries_file_uri and self.check_for_output_file(boundaries_file_uri):
             self.get_logger(session).info(f"Boundaries file found, using it: {boundaries_file_uri}")
             with self.fetch_file(boundaries_file_uri) as f:
-                boundaries = list(map(lambda l: tuple(l), json.load(f)))
+                boundaries = list(map(tuple, json.load(f)))
 
         else:
             # The percentage needs to be pretty small, since the collect
@@ -316,8 +316,8 @@ class ZipNumClusterCdx(CCFileProcessorSparkJob):
             numPartitions=num_partitions,
             partitionFunc=lambda k: ZipNumClusterCdx.get_partition_id(k, boundaries)) \
             .mapPartitionsWithIndex(
-                lambda idx, iter: ZipNumClusterCdx.process_partition(
-                    idx, iter, num_lines, output_base_url, temporary_output_base_url)) \
+                lambda idx, _iter: ZipNumClusterCdx.process_partition(
+                    idx, _iter, num_lines, output_base_url, temporary_output_base_url)) \
             .collect()
 
         # loop over the output files and concatenate them into a single final file
@@ -328,7 +328,7 @@ class ZipNumClusterCdx(CCFileProcessorSparkJob):
                         f.write(line)
 
         with open('cluster.idx', 'rb') as f:
-            self.write_output_file('cluster.idx', f, output_base_url)
+            ZipNumClusterCdx.write_output_file('cluster.idx', f, output_base_url)
 
         os.unlink('cluster.idx')
 

--- a/zipnumcluster_cc_pyspark.py
+++ b/zipnumcluster_cc_pyspark.py
@@ -73,18 +73,20 @@ class ZipNumClusterCdx(CCFileProcessorSparkJob):
             return None
 
     @staticmethod
-    def remove_cdx_fields(value: Tuple[Tuple[str, str], str], remove_fields: Set[str]) -> str:
+    def remove_cdx_fields(value: Tuple[Tuple[str, str], str],
+                          remove_fields: Set[str]) -> Tuple[Tuple[str, str], str]:
         data = json.loads(value[1])
         for f in remove_fields:
             if f in data:
                 del data[f]
-        return (value[0], json.dumps(data))
+        return value[0], json.dumps(data)
 
     @staticmethod
-    def keep_only_cdx_fields(value: Tuple[Tuple[str, str], str], keep_fields: Set[str]) -> str:
+    def keep_only_cdx_fields(value: Tuple[Tuple[str, str], str],
+                             keep_fields: Set[str]) -> Tuple[Tuple[str, str], str]:
         data = json.loads(value[1])
         data = {k: v for k, v in data.items() if k in keep_fields}
-        return (value[0], json.dumps(data))
+        return value[0], json.dumps(data)
 
     @staticmethod
     def get_partition_id(key: str, boundaries_data) -> int:


### PR DESCRIPTION
 The per-WARC CDX files used as input for the ZipNum Sharded CDXJ index might include fields which are not intended to be used in the large index. This PR adds options to strip fields while the ZipNum is built.
 
 - Add option `--cdx_output_remove_fields` to remove fields.
 - Add option `--cdx_output_fields` to restrict the fields in the ZipNum output to a given set of field names.
 - Configure list of CDXJ fields used for Common Crawl's ZipNum index.
 
Unrelated changes (code improvements):
- call static function not using `self` but the class name
- do not wrap function call in lambdas, if not needed
- rename variable "iter" (reserved keyword)


